### PR TITLE
pipeline: print image tag in summary for easier deployment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Write Image Tag
         run: echo "IMAGE_TAG=$IMAGE_TAG" > image-tag.txt
       
+      - name: Summarise job
+        run: 'echo "Pushed image with tag: $IMAGE_TAG" >> $GITHUB_STEP_SUMMARY'
+      
       - name: publish image tag
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
small change to output the tag of the image pushed to dockerhub to make it easier to get if I want to manually deploy a branch